### PR TITLE
Added social-media links to the footer

### DIFF
--- a/app/components/layout/blocks/aligned-block.tsx
+++ b/app/components/layout/blocks/aligned-block.tsx
@@ -11,10 +11,7 @@ export function AlignedBlock({
   containerClassName?: string
 }) {
   return (
-    <Block
-      className={clsx('w-full mx-auto px-4 sm:px-8', containerClassName)}
-      {...props}
-    >
+    <Block className={containerClassName} {...props}>
       <div
         className={clsx(
           align === 'right' && 'ml-auto',

--- a/app/components/layout/blocks/block.tsx
+++ b/app/components/layout/blocks/block.tsx
@@ -11,6 +11,7 @@ export function Block({
   return (
     <section
       className={clsx(
+        'w-full mx-auto px-4 sm:px-8',
         maxW === '4xl' && 'max-w-4xl',
         maxW === '7xl' && 'max-w-7xl',
         props.className

--- a/app/components/layout/footer.tsx
+++ b/app/components/layout/footer.tsx
@@ -1,6 +1,7 @@
 import { AdaptiveFullSignature } from '~/components/logo'
 import { Wavezz } from '~/components/wavezz'
-import { AlignedBlock } from '~/components/layout/blocks/aligned-block'
+import { Block } from './blocks/block'
+import { ALink } from '../buttons'
 
 export function Footer() {
   return (
@@ -11,15 +12,20 @@ export function Footer() {
       />
 
       <footer className="bg-slate-100 dark:bg-black pb-20">
-        <AlignedBlock containerClassName="grid md:grid-cols-4 items-center w-full space-y-8 lg:space-y-0 lg:space-x-8 app-text">
-          <div className="flex flex-col space-y-8">
+        <Block className="mx-auto flex flex-col md:flex-row md:items-center w-full space-y-8 lg:space-y-0 lg:space-x-8 app-text justify-between">
+          <div className="flex flex-col space-y-8 max-w-xs">
             <AdaptiveFullSignature />
 
             <p className="text-lg leading-relaxed font-medium">
               Crafting adaptive high-quality experiences for the Web.
             </p>
           </div>
-        </AlignedBlock>
+          <div className="space-x-2">
+            <ALink href="https://github.com/rowinbot">GitHub</ALink>
+            <ALink href="https://twitter.com/rowinbot">Twiter</ALink>
+            <ALink href="https://www.linkedin.com/in/rowinbot/">LinkedIn</ALink>
+          </div>
+        </Block>
       </footer>
     </>
   )


### PR DESCRIPTION
## Summary
This PR adds to the footer social-media links.

## Changes:
1. Changed from AlignedBlock to Block.
2. Added ALink
3. The Block container is Flex instead of grid to make it easier and aesthetically pleasing to add the links.
4. Added social-media links to GitHub, Twitter and LinkedIn using ALink.
